### PR TITLE
V1alpha2 apiserviceexport patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,6 +255,9 @@ $(KCP):
 	tar xz -C "$(TOOLS_DIR)" --strip-components="1" bin/kcp
 	mv $(TOOLS_DIR)/kcp $(KCP)
 
+run-kcp: $(KCP)
+	$(KCP) start
+
 .PHONY: test-e2e
 ifdef USE_GOTESTSUM
 test-e2e: $(GOTESTSUM)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ accessible.
 and that you have at least one k8s cluster. Take a look at the backend option in the cmd/main.go file***
 
 * apply the CRDs: `kubectl apply -f deploy/crd`
-* In order to populate binding list on website, we need a CRD with label `kube-bind.io/exported: true`. Apply example CRD: `kubectl apply -f deploy/examples/crd-mangodb.yaml`
+* In order to populate binding list on website, we need a CRD with label `kube-bind.io/exported: true`. Apply example CRD: `kubectl apply -f deploy/examples/apiresourceschema.yaml`
 * start the backend binary with the right flags:
 ```shell
 $ make build

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ accessible.
 and that you have at least one k8s cluster. Take a look at the backend option in the cmd/main.go file***
 
 * apply the CRDs: `kubectl apply -f deploy/crd`
-* In order to populate binding list on website, we need a CRD with label `kube-bind.io/exported: true`. Apply example CRD: `kubectl apply -f deploy/examples/apiresourceschema.yaml`
+* In order to populate binding list on website, we need a CRD with label `kube-bind.io/exported: true`. Apply example APIResourceSchema for the CRD: `kubectl apply -f deploy/examples/apiresourceschema.yaml`
 * start the backend binary with the right flags:
 ```shell
 $ make build

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ All the actions shown between the clusters are done by the konnector, except: th
 
 ## Usage
 
+This section allows you to run local kube-bind backend and konnector.
+The main challenge when running it locally is to have multiple clusters available and accessible.
+
+For this we use [kcp](https://github.com/kcp-dev/kcp) to create a local clusters under single kcp instance.
+By having a single kcp instance, we can have multiple clusters available and accessible via same url.
+
+To run kcp, you need to have a kcp binary.
+
+```shell
+$ make run-kcp
+```
+
 To run the current backend, there must be an OIDC issuer installed in place to do the
 the oauth2 workflow.
 
@@ -83,8 +95,16 @@ accessible.
 ***Note: make sure before running the backend that you have the dex server up and running as mentioned above
 and that you have at least one k8s cluster. Take a look at the backend option in the cmd/main.go file***
 
+Create copy of kcp kubeconfig and create provider cluster:
+
+```shell
+$ cp .kcp/admin.kubeconfig .kcp/provider.kubeconfig
+$ export KUBECONFIG=.kcp/provider.kubeconfig
+$ kubectl ws create provider --enter
+```
+
 * apply the CRDs: `kubectl apply -f deploy/crd`
-* In order to populate binding list on website, we need a CRD with label `kube-bind.io/exported: true`. Apply example APIResourceSchema for the CRD: `kubectl apply -f deploy/examples/apiresourceschema.yaml`
+* In order to populate binding list on website, we need a CRD with label `kube-bind.io/exported: true`. Apply example APIResourceSchema for the CRD: `kubectl apply -f deploy/examples/crd-mangodb.yaml`
 * start the backend binary with the right flags:
 ```shell
 $ make build
@@ -110,4 +130,30 @@ WQh88mNOY0Z3tLy1/WOud7qIEEBxz+POc4j8BsYenYo=
 The `--cookie-signing-key` option is required and supports 32 and 64 byte lengths.
 The `--cookie-encryption-key` option is optional and supports byte lengths of 16, 24, 32 for AES-128, AES-192, or AES-256.
 
-* with a KUBECONFIG against another cluster (a consumer cluster) bind a service: `kubectl bind http://127.0.0.1:8080/export`.
+### Consumer 
+Now create consumer cluster:
+
+```shell
+$ export KUBECONFIG=.kcp/admin.kubeconfig
+$ kubectl ws create consumer --enter
+```
+
+Now create the APIServiceExportRequest:
+
+```shell
+$ ./bin/kubectl-bind http://127.0.0.1:8080/export --dry-run -o yaml > apiserviceexport.yaml
+# This will wait for konnector to be ready. Once this gets running - start the konnector bellow
+$ ./bin/kubectl-bind apiservice --remote-namespace kube-bind-77wsg --remote-kubeconfig .kcp/provider.kubeconfig -f apiserviceexport.yaml  --skip-konnector
+# run konnector
+$ go run ./cmd/konnector/ --lease-namespace default
+```
+
+### Limitations
+
+These limitations are part of the roadmap and will be addressed in the future.
+
+* Currently we don't support related resources, like ConfigMaps, Secrets
+* Currently CRD resources MUST be installed in the provider cluster, even when APIResourceSchema is used.
+  This is to allow the konnector to sync instances of the CRD to the consumer cluster.
+  This should be removed once we introduce sync policies and object wrappers.
+* Currently we dont support granular permissions, like only allow to read/write certain named resources.

--- a/cli/pkg/kubectl/bind/plugin/authenticate.go
+++ b/cli/pkg/kubectl/bind/plugin/authenticate.go
@@ -72,8 +72,9 @@ func getProvider(url string, insecure bool) (*kubebindv1alpha2.BindingProvider, 
 	}
 	if bindSemVer, err := semver.Parse(strings.TrimLeft(bindVersion, "v")); err != nil {
 		return nil, fmt.Errorf("failed to parse bind version %q: %v", bindVersion, err)
-	} else if min := semver.MustParse("0.3.0"); bindSemVer.GE(min) {
-		// we added this in v0.3.0. Don't test before.
+	} else if min := semver.MustParse("0.5.0"); bindSemVer.GE(min) {
+		// At v0.5.0 we made breaking change for how APIExports looks like.
+		// So we need to test for v0.5.0+. If
 		if err := validateProviderVersion(provider.Version); err != nil {
 			return nil, err
 		}
@@ -84,7 +85,7 @@ func getProvider(url string, insecure bool) (*kubebindv1alpha2.BindingProvider, 
 
 func validateProviderVersion(providerVersion string) error {
 	if providerVersion == "" {
-		return fmt.Errorf("provider version %q is empty, please update the backend to v0.3.0+", providerVersion)
+		return fmt.Errorf("provider version %q is empty, please update the backend to v0.5.0+", providerVersion)
 	} else if providerVersion == "v0.0.0" || providerVersion == "v0.0.0-master+$Format:%H$" {
 		// unversioned, development version
 		return nil
@@ -94,7 +95,8 @@ func validateProviderVersion(providerVersion string) error {
 	if err != nil {
 		return fmt.Errorf("provider version %q cannot be parsed", providerVersion)
 	}
-	if min := semver.MustParse("0.3.0"); providerSemVer.LT(min) {
+	// Check if provider is higher than 0.4.8, we need to have same version of kube-bind to use this provider.
+	if min := semver.MustParse("0.5.0"); providerSemVer.LT(min) {
 		return fmt.Errorf("provider version %s is not supported, must be at least v%s", providerVersion, min)
 	}
 

--- a/contrib/example-backend/controllers/clusterbinding/clusterbinding_reconcile.go
+++ b/contrib/example-backend/controllers/clusterbinding/clusterbinding_reconcile.go
@@ -154,11 +154,18 @@ func (r *reconciler) ensureRBACClusterRole(ctx context.Context, clusterBinding *
 				return fmt.Errorf("failed to get APIResourceSchema %w", err)
 			}
 
-			expected.Rules = append(expected.Rules, rbacv1.PolicyRule{
-				APIGroups: []string{schema.Spec.APIResourceSchemaCRDSpec.Group},
-				Resources: []string{schema.Spec.APIResourceSchemaCRDSpec.Names.Plural},
-				Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
-			})
+			expected.Rules = append(expected.Rules,
+				rbacv1.PolicyRule{
+					APIGroups: []string{schema.Spec.APIResourceSchemaCRDSpec.Group},
+					Resources: []string{schema.Spec.APIResourceSchemaCRDSpec.Names.Plural},
+					Verbs:     []string{"get", "list", "watch", "update", "patch", "delete", "create"},
+				},
+				rbacv1.PolicyRule{
+					APIGroups: []string{kubebindv1alpha2.GroupName},
+					Resources: []string{"apiresourceschemas"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+			)
 		}
 	}
 

--- a/contrib/example-backend/controllers/serviceexport/serviceexport_controller.go
+++ b/contrib/example-backend/controllers/serviceexport/serviceexport_controller.go
@@ -79,7 +79,7 @@ func NewController(
 			getCRD: func(name string) (*apiextensionsv1.CustomResourceDefinition, error) {
 				return crdInformer.Lister().Get(name)
 			},
-			getAPIResourceSchema: func(ctx context.Context, ns, name string) (*kubebindv1alpha2.APIResourceSchema, error) {
+			getAPIResourceSchema: func(ctx context.Context, name string) (*kubebindv1alpha2.APIResourceSchema, error) {
 				return bindClient.KubeBindV1alpha2().APIResourceSchemas().Get(ctx, name, metav1.GetOptions{})
 			},
 			deleteServiceExport: func(ctx context.Context, ns, name string) error {

--- a/contrib/example-backend/controllers/serviceexportrequest/serviceexportrequest_reconcile.go
+++ b/contrib/example-backend/controllers/serviceexportrequest/serviceexportrequest_reconcile.go
@@ -37,6 +37,7 @@ type reconciler struct {
 	clusterScopedIsolation kubebindv1alpha2.Isolation
 
 	getCRD                     func(name string) (*apiextensionsv1.CustomResourceDefinition, error)
+	getAPIResourceSchema       func(ctx context.Context, name string) (*kubebindv1alpha2.APIResourceSchema, error)
 	getServiceExport           func(ns, name string) (*kubebindv1alpha2.APIServiceExport, error)
 	createServiceExport        func(ctx context.Context, resource *kubebindv1alpha2.APIServiceExport) (*kubebindv1alpha2.APIServiceExport, error)
 	createAPIResourceSchema    func(ctx context.Context, schema *kubebindv1alpha2.APIResourceSchema) (*kubebindv1alpha2.APIResourceSchema, error)
@@ -61,22 +62,41 @@ func (r *reconciler) ensureExports(ctx context.Context, req *kubebindv1alpha2.AP
 	if req.Status.Phase == kubebindv1alpha2.APIServiceExportRequestPhasePending {
 		failure := false
 		for _, res := range req.Spec.Resources {
+			// backend is created using CRD's as backup. But this is not required.
 			name := res.Resource + "." + res.Group
-			crd, err := r.getCRD(name)
-			if err != nil && !apierrors.IsNotFound(err) {
+
+			apiResourceSchema, err := r.getAPIResourceSchema(ctx, name)
+			switch {
+			case apierrors.IsNotFound(err):
+				logger.V(1).Info("APIResourceSchema not found, continuing with fallback to CRD conversion to APIResourceSchema", "name", name)
+				crd, err := r.getCRD(name)
+				if err != nil && !apierrors.IsNotFound(err) {
+					return err
+				}
+				if apierrors.IsNotFound(err) {
+					conditions.MarkFalse(
+						req,
+						kubebindv1alpha2.APIServiceExportRequestConditionExportsReady,
+						"CRDNotFound",
+						conditionsapi.ConditionSeverityError,
+						"CustomResourceDefinition %s in the service provider cluster not found",
+						name,
+					)
+					failure = true
+					break
+				}
+				schema, err := helpers.CRDToAPIResourceSchema(crd, "")
+				if err != nil {
+					return err
+				}
+				schema.Namespace = req.Namespace
+
+				logger.V(1).Info("Creating APIResourceSchema", "name", schema.Name, "namespace", schema.Namespace)
+				if apiResourceSchema, err = r.createAPIResourceSchema(ctx, schema); err != nil {
+					return err
+				}
+			case err != nil:
 				return err
-			}
-			if apierrors.IsNotFound(err) {
-				conditions.MarkFalse(
-					req,
-					kubebindv1alpha2.APIServiceExportRequestConditionExportsReady,
-					"CRDNotFound",
-					conditionsapi.ConditionSeverityError,
-					"CustomResourceDefinition %s in the service provider cluster not found",
-					name,
-				)
-				failure = true
-				break
 			}
 
 			if _, err := r.getServiceExport(req.Namespace, name); err != nil && !apierrors.IsNotFound(err) {
@@ -85,25 +105,10 @@ func (r *reconciler) ensureExports(ctx context.Context, req *kubebindv1alpha2.AP
 				continue
 			}
 
-			schema, err := helpers.CRDToAPIResourceSchema(crd, "")
-			if err != nil {
-				conditions.MarkFalse(
-					req,
-					kubebindv1alpha2.APIServiceExportRequestConditionExportsReady,
-					"CRDInvalid",
-					conditionsapi.ConditionSeverityError,
-					"CustomResourceDefinition %s cannot be converted to a APIServiceExport: %v",
-					name,
-					err,
-				)
-				failure = true
-				break
-			}
-			hash := helpers.APIResourceSchemaCRDSpecHash(&schema.Spec.APIResourceSchemaCRDSpec)
-			schema.Namespace = req.Namespace
+			hash := helpers.APIResourceSchemaCRDSpecHash(&apiResourceSchema.Spec.APIResourceSchemaCRDSpec)
 			export := &kubebindv1alpha2.APIServiceExport{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      crd.Name,
+					Name:      req.Name,
 					Namespace: req.Namespace,
 					Annotations: map[string]string{
 						kubebindv1alpha2.SourceSpecHashAnnotationKey: hash,
@@ -113,19 +118,16 @@ func (r *reconciler) ensureExports(ctx context.Context, req *kubebindv1alpha2.AP
 					Resources: []kubebindv1alpha2.APIResourceSchemaReference{
 						{
 							Type: "APIResourceSchema",
-							Name: schema.Name,
+							Name: apiResourceSchema.Name,
 						},
 					},
 					InformerScope: r.informerScope,
 				},
 			}
-			if schema.Spec.Scope == apiextensionsv1.ClusterScoped {
+			if apiResourceSchema.Spec.Scope == apiextensionsv1.ClusterScoped {
 				export.Spec.ClusterScopedIsolation = r.clusterScopedIsolation
 			}
-			logger.V(1).Info("Creating APIResourceSchema", "name", schema.Name, "namespace", schema.Namespace)
-			if _, err = r.createAPIResourceSchema(ctx, schema); err != nil {
-				return err
-			}
+
 			logger.V(1).Info("Creating APIServiceExport", "name", export.Name, "namespace", export.Namespace)
 			if _, err = r.createServiceExport(ctx, export); err != nil {
 				return err

--- a/contrib/example-backend/http/server.go
+++ b/contrib/example-backend/http/server.go
@@ -18,6 +18,7 @@ package http
 
 import (
 	"context"
+	"log"
 	"net"
 	"net/http"
 	"strconv"
@@ -62,6 +63,7 @@ func (s *Server) Addr() net.Addr {
 }
 
 func (s *Server) Start(ctx context.Context) error {
+	log.Println("Starting HTTP server")
 	server := &http.Server{
 		Handler:           s.Router,
 		ReadHeaderTimeout: 1 * time.Minute,
@@ -73,8 +75,10 @@ func (s *Server) Start(ctx context.Context) error {
 
 	go func() {
 		if s.options.KeyFile == "" {
+			log.Println("Serving HTTP on", s.listener.Addr())
 			server.Serve(s.listener) //nolint:errcheck
 		} else {
+			log.Println("Serving HTTPS on", s.listener.Addr())
 			server.ServeTLS(s.listener, s.options.CertFile, s.options.KeyFile) //nolint:errcheck
 		}
 	}()

--- a/contrib/example-backend/kubernetes/manager.go
+++ b/contrib/example-backend/kubernetes/manager.go
@@ -32,6 +32,7 @@ import (
 
 	kuberesources "github.com/kube-bind/kube-bind/contrib/example-backend/kubernetes/resources"
 	"github.com/kube-bind/kube-bind/pkg/indexers"
+	kubebindv1alpha2 "github.com/kube-bind/kube-bind/sdk/apis/kubebind/v1alpha2"
 	bindclient "github.com/kube-bind/kube-bind/sdk/client/clientset/versioned"
 	bindinformers "github.com/kube-bind/kube-bind/sdk/client/informers/externalversions/kubebind/v1alpha2"
 	bindlisters "github.com/kube-bind/kube-bind/sdk/client/listers/kubebind/v1alpha2"
@@ -161,4 +162,8 @@ func (m *Manager) HandleResources(ctx context.Context, identity, resource, group
 	}
 
 	return kfgSecret.Data["kubeconfig"], nil
+}
+
+func (m *Manager) ListAPIResourceSchemas(ctx context.Context) (*kubebindv1alpha2.APIResourceSchemaList, error) {
+	return m.bindClient.KubeBindV1alpha2().APIResourceSchemas().List(ctx, metav1.ListOptions{})
 }

--- a/contrib/example-backend/server.go
+++ b/contrib/example-backend/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log"
 	"net"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -165,6 +166,7 @@ func NewServer(config *Config) (*Server, error) {
 		config.BindInformers.KubeBind().V1alpha2().APIServiceExportRequests(),
 		config.BindInformers.KubeBind().V1alpha2().APIServiceExports(),
 		config.ApiextensionsInformers.Apiextensions().V1().CustomResourceDefinitions(),
+		config.BindInformers.KubeBind().V1alpha2().APIResourceSchemas(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up ServiceExportRequest Controller: %w", err)
@@ -214,6 +216,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 	go func() {
 		<-ctx.Done()
+		log.Println("Context done")
 	}()
 	return s.WebServer.Start(ctx)
 }

--- a/contrib/example-backend/template/resources.gohtml
+++ b/contrib/example-backend/template/resources.gohtml
@@ -8,9 +8,10 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 
-    <title>Resources</title>
+    <title>Resources - CRD</title>
   </head>
   <body>
+    <h2>CRD</h2>
     <div class="card-deck text-center">
       {{$sid := .SessionID}}{{range .CRDs}}
       <div class="card box-shadow" style="width:18rem; min-width:18rem; max-width:18rem; margin-bottom: 2rem;">
@@ -25,7 +26,21 @@
       </div>
       {{end}}
     </div>
-
+    <h2>APIResourceSchema</h2>
+    <div class="card-deck text-center">
+      {{$sid := .SessionID}}{{range .APIResourceSchemas}}
+      <div class="card box-shadow" style="width:18rem; min-width:18rem; max-width:18rem; margin-bottom: 2rem;">
+        <div class="card-header"><h4>{{.Spec.Names.Singular}}</h4></div>
+        <ul class="list-group list-group-flush">
+          <li class="list-group-item">Group: {{.Spec.Group}}</li>
+          <li class="list-group-item">Scope: {{.Spec.Scope}}</li>
+        </ul>
+         <div class="card-body">
+          <a href="/bind?s={{$sid}}&resource={{.Spec.Names.Plural}}&group={{.Spec.Group}}" class="btn btn-lg btn-block btn-primary {{.Spec.Names.Plural}}">Bind</a>
+        </div>
+      </div>
+     {{end}}
+    </div>
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>

--- a/deploy/crd/kube-bind.io_apiresourceschemas.yaml
+++ b/deploy/crd/kube-bind.io_apiresourceschemas.yaml
@@ -13,6 +13,8 @@ spec:
     kind: APIResourceSchema
     listKind: APIResourceSchemaList
     plural: apiresourceschemas
+    shortNames:
+    - as
     singular: apiresourceschema
   scope: Cluster
   versions:

--- a/deploy/examples/apiresourceschema.yaml
+++ b/deploy/examples/apiresourceschema.yaml
@@ -1,0 +1,39 @@
+apiVersion: kube-bind.io/v1alpha2
+kind: APIResourceSchema
+metadata:
+  name: mangodbs.mangodb.com
+spec:
+  informerScope: Namespaced
+  group: mangodb.com
+  names:
+    kind: MangoDB
+    listKind: MangoDBList
+    plural: mangodbs
+    singular: mangodb
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                tier:
+                  type: string
+                  enum:
+                    - Dedicated
+                    - Shared
+                  default: Shared
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+          required:
+            - spec
+      subresources:
+        status: {}

--- a/deploy/examples/mangodb.yaml
+++ b/deploy/examples/mangodb.yaml
@@ -1,0 +1,12 @@
+apiVersion: mangodb.com/v1alpha1
+kind: MangoDB
+
+metadata:
+  name: my-first-mangodb-instance
+  namespace: default
+
+spec:
+  tier: Dedicated
+
+status:
+  phase: Pending

--- a/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile.go
+++ b/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile.go
@@ -145,7 +145,6 @@ func (r *reconciler) ensureCRDs(ctx context.Context, binding *kubebindv1alpha2.A
 	// If we processed all schemas without errors, mark the binding as connected
 	if len(errs) == 0 && !conditions.IsFalse(binding, kubebindv1alpha2.APIServiceBindingConditionConnected) {
 		conditions.MarkTrue(binding, kubebindv1alpha2.APIServiceBindingConditionConnected)
-		// TODO(mjudeikis): Is this really right place?
 		conditions.MarkTrue(binding, kubebindv1alpha2.APIServiceBindingConditionSchemaInSync)
 	}
 

--- a/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile.go
+++ b/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile.go
@@ -127,7 +127,8 @@ func (r *reconciler) ensureCRDs(ctx context.Context, binding *kubebindv1alpha2.A
 			"Failed to fetch APIResourceSchema objects: %s",
 			err,
 		)
-		return nil
+		// We dont have schema - try again. Might be a race on provider side.
+		return err
 	}
 
 	// Process each schema

--- a/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile.go
+++ b/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile.go
@@ -144,6 +144,8 @@ func (r *reconciler) ensureCRDs(ctx context.Context, binding *kubebindv1alpha2.A
 	// If we processed all schemas without errors, mark the binding as connected
 	if len(errs) == 0 && !conditions.IsFalse(binding, kubebindv1alpha2.APIServiceBindingConditionConnected) {
 		conditions.MarkTrue(binding, kubebindv1alpha2.APIServiceBindingConditionConnected)
+		// TODO(mjudeikis): Is this really right place?
+		conditions.MarkTrue(binding, kubebindv1alpha2.APIServiceBindingConditionSchemaInSync)
 	}
 
 	return utilerrors.NewAggregate(errs)

--- a/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile_test.go
+++ b/pkg/konnector/controllers/cluster/servicebinding/servicebinding_reconcile_test.go
@@ -54,6 +54,7 @@ func TestEnsureCRDs(t *testing.T) {
 			}),
 			expectConditions: conditionsapi.Conditions{
 				conditionsapi.Condition{Type: "Connected", Status: "True"},
+				conditionsapi.Condition{Type: "SchemaInSync", Status: "True"},
 			},
 		},
 		{


### PR DESCRIPTION
<!--

Thanks for creating a pull request!
If this is your first time, please make sure to review CONTRIBUTING.MD.

-->

## Summary

1. Move backend to list both crds and apiresourceschemas. This way we can use same kind cluster locally and it works. Else it complains crd already exists. I think this could be worked around using kcp!
2. Add version gate


## What Type of PR Is This?

<!--

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression

-->

## Related Issue(s)

Fixes #

## Release Notes

<!--
Please add a release note in the block below. Leave NONE only if no user-facing changes are in this PR.
-->

```release-note
NONE
```
